### PR TITLE
Fix typo in schema for collection_id field name

### DIFF
--- a/approved-books.json
+++ b/approved-books.json
@@ -1,3 +1,3 @@
 [
-  {"name": "example-book", "server": "qa.cnx.org", "collection-id": "col12345", "version": "0.1.0", "style": "example" }
+  {"name": "example-book", "server": "qa.cnx.org", "collection_id": "col12345", "version": "0.1.0", "style": "example" }
 ]

--- a/schema.json
+++ b/schema.json
@@ -30,7 +30,8 @@
           "description": "Style to apply to the collection"
         }
       },
-      "required": ["server", "collection-id", "version", "style"]
+      "required": ["server", "collection_id", "version", "style"],
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
There was a typo in the field name which wasn't apparent due to the
schema treating the field as an additional property. In addition to
fixing the typo also setting the schema to not allow additional
properties.