### PR TITLE
Add initial book-slugs.json

### DIFF
--- a/book-slugs.json
+++ b/book-slugs.json
@@ -1,0 +1,202 @@
+[
+    {
+        "uuid": "02040312-72c8-441e-a685-20e9333f3e1d",
+        "slug": "introduction-sociology-2e"
+    },
+    {
+        "uuid": "031da8d3-b525-429c-80cf-6c8ed997733a",
+        "slug": "college-physics"
+    },
+    {
+        "uuid": "06aba565-9432-40f6-97ee-b8a361f118a8",
+        "slug": "psychology-2e"
+    },
+    {
+        "uuid": "13ac107a-f15f-49d2-97e8-60ab2e3b519c",
+        "slug": "algebra-and-trigonometry"
+    },
+    {
+        "uuid": "14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22",
+        "slug": "anatomy-and-physiology"
+    },
+    {
+        "uuid": "16ab5b96-4598-45f9-993c-b8d78d82b0c6",
+        "slug": "fizyka-dla-szkół-wyższych-tom-2"
+    },
+    {
+        "uuid": "1d39a348-071f-4537-85b6-c98912458c3c",
+        "slug": "calculus-volume-2"
+    },
+    {
+        "uuid": "27f59064-990e-48f1-b604-5188b9086c29",
+        "slug": "principles-macroeconomics-2e"
+    },
+    {
+        "uuid": "2d941ab9-ac5b-4eb8-b21c-965d36a4f296",
+        "slug": "organizational-behavior"
+    },
+    {
+        "uuid": "2e737be8-ea65-48c3-aa0a-9f35b4c6a966",
+        "slug": "astronomy"
+    },
+    {
+        "uuid": "30189442-6998-4686-ac05-ed152b91b9de",
+        "slug": "introductory-statistics"
+    },
+    {
+        "uuid": "36004586-651c-4ded-af87-203aca22d946",
+        "slug": "life-liberty-and-pursuit-happiness"
+    },
+    {
+        "uuid": "394a1101-fd8f-4875-84fa-55f15b06ba66",
+        "slug": "statistics"
+    },
+    {
+        "uuid": "464a3fba-68c1-426a-99f9-597e739dc911",
+        "slug": "business-law-i-essentials"
+    },
+    {
+        "uuid": "4664c267-cd62-4a99-8b28-1cb9b3aee347",
+        "slug": "intermediate-algebra-2e"
+    },
+    {
+        "uuid": "4abf04bf-93a0-45c3-9cbc-2cefd46e68cc",
+        "slug": "psychology"
+    },
+    {
+        "uuid": "4e09771f-a8aa-40ce-9063-aa58cc24e77f",
+        "slug": "introduction-business"
+    },
+    {
+        "uuid": "4eaa8f03-88a8-485a-a777-dd3602f6c13e",
+        "slug": "fizyka-dla-szkół-wyższych-tom-1"
+    },
+    {
+        "uuid": "507feb1e-cfff-4b54-bc07-d52636cecfe3",
+        "slug": "college-algebra-corequisite-support"
+    },
+    {
+        "uuid": "55931856-c627-418b-a56f-1dd0007683a8",
+        "slug": "elementary-algebra-2e"
+    },
+    {
+        "uuid": "5c09762c-b540-47d3-9541-dda1f44f16e5",
+        "slug": "principles-microeconomics-2e"
+    },
+    {
+        "uuid": "636cbfd9-4e37-4575-83ab-9dec9029ca4e",
+        "slug": "principles-microeconomics-ap-courses-2e"
+    },
+    {
+        "uuid": "6c322e32-9fb0-4c4d-a1d7-20c95c5c7af2",
+        "slug": "biology-ap-courses"
+    },
+    {
+        "uuid": "7a0f9770-1c44-4acd-9920-1cd9a99f2a1e",
+        "slug": "university-physics-volume-2"
+    },
+    {
+        "uuid": "7fccc9cf-9b71-44f6-800b-f9457fd64335",
+        "slug": "chemistry-2e"
+    },
+    {
+        "uuid": "8b89d172-2927-466f-8661-01abc7ccdba4",
+        "slug": "calculus-volume-1"
+    },
+    {
+        "uuid": "8d04a686-d5e8-4798-a27d-c608e4d0e187",
+        "slug": "college-physics-ap-courses"
+    },
+    {
+        "uuid": "8d50a0af-948b-4204-a71d-4826cba765b8",
+        "slug": "biology-2e"
+    },
+    {
+        "uuid": "9117cf8c-a8a3-4875-8361-9cb0f1fc9362",
+        "slug": "principles-macroeconomics-ap-courses-2e"
+    },
+    {
+        "uuid": "914ac66e-e1ec-486d-8a9c-97b0f7a99774",
+        "slug": "business-ethics"
+    },
+    {
+        "uuid": "920d1c8a-606c-4888-bfd4-d1ee27ce1795",
+        "slug": "principles-managerial-accounting"
+    },
+    {
+        "uuid": "9ab4ba6d-1e48-486d-a2de-38ae1617ca84",
+        "slug": "principles-financial-accounting"
+    },
+    {
+        "uuid": "9b08c294-057f-4201-9f48-5d6ad992740d",
+        "slug": "college-algebra"
+    },
+    {
+        "uuid": "9d8df601-4f12-4ac1-8224-b450bf739e5f",
+        "slug": "american-government-2e"
+    },
+    {
+        "uuid": "a31cd793-2162-4e9e-acb5-6e6bbd76a5fa",
+        "slug": "calculus-volume-3"
+    },
+    {
+        "uuid": "a7ba2fb8-8925-4987-b182-5f4429d48daa",
+        "slug": "us-history"
+    },
+    {
+        "uuid": "af275420-6050-4707-995c-57b9cc13c358",
+        "slug": "university-physics-volume-3"
+    },
+    {
+        "uuid": "b3c1e1d2-839c-42b0-a314-e119a8aafbdd",
+        "slug": "concepts-biology"
+    },
+    {
+        "uuid": "b56bb9e9-5eb8-48ef-9939-88b1b12ce22f",
+        "slug": "introductory-business-statistics"
+    },
+    {
+        "uuid": "bb62933e-f20a-4ffc-90aa-97b36c296c3e",
+        "slug": "fizyka-dla-szkół-wyższych-tom-3"
+    },
+    {
+        "uuid": "bc498e1f-efe9-43a0-8dea-d3569ad09a82",
+        "slug": "principles-economics-2e"
+    },
+    {
+        "uuid": "c3acb2ab-7d5c-45ad-b3cd-e59673fedd4e",
+        "slug": "principles-management"
+    },
+    {
+        "uuid": "cce64fde-f448-43b8-ae88-27705cceb0da",
+        "slug": "physics"
+    },
+    {
+        "uuid": "d380510e-6145-4625-b19a-4fa68204b6b1",
+        "slug": "entrepreneurship"
+    },
+    {
+        "uuid": "d50f6e32-0fda-46ef-a362-9bd36ca7c97d",
+        "slug": "university-physics-volume-1"
+    },
+    {
+        "uuid": "d9b85ee6-c57f-4861-8208-5ddf261e9c5f",
+        "slug": "chemistry-atoms-first-2e"
+    },
+    {
+        "uuid": "e42bd376-624b-4c0f-972f-e0c57998e765",
+        "slug": "microbiology"
+    },
+    {
+        "uuid": "e8668a14-9a7d-4d74-b58c-3681f8351224",
+        "slug": "college-success"
+    },
+    {
+        "uuid": "f0fa90be-fca8-43c9-9aad-715c0a2cee2b",
+        "slug": "prealgebra-2e"
+    },
+    {
+        "uuid": "fd53eae1-fa23-47c7-bb1b-972349835c3c",
+        "slug": "precalculus"
+    }
+]

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ const Ajv = require('ajv')
 
 const booksListPath = path.resolve('./approved-books.json')
 const schemaPath = path.resolve('./schema.json')
+const bookSlugsPath = path.resolve('./book-slugs.json')
 
 test('approved-books.json is JSON', t => {
   const listData = fs.readFileSync(booksListPath, { encoding: 'utf8' })
@@ -40,5 +41,37 @@ test('approved-books.json has no duplicate entries', t => {
     acc.push(book)
     return acc
   }, [])
+  t.pass()
+})
+
+test('book-slugs.json has no duplicate UUIDs', t => {
+  const listData = fs.readFileSync(bookSlugsPath, { encoding: 'utf8' })
+  const list = JSON.parse(listData)
+  list.reduce((acc, book) => {
+    if (acc.includes(book.uuid)) {
+      t.fail(`Duplicate slugs found for UUID: ${book.uuid}`)
+    }
+    acc.push(book.uuid)
+    return acc
+  }, [])
+  t.pass()
+})
+
+test('all approved books have a slug defined in book-slugs.json', t => {
+  const slugData = fs.readFileSync(bookSlugsPath, { encoding: 'utf8' })
+  const bookData = fs.readFileSync(booksListPath, { encoding: 'utf8' })
+  const books = JSON.parse(bookData)
+  const slugs = JSON.parse(slugData)
+
+  bookToSlugs = slugs.reduce((acc, book) => {
+    acc[book['uuid']] = book['slug']
+    return acc
+  }, {})
+
+  books.forEach(book => {
+    if (!(book['uuid'] in bookToSlugs)) {
+      t.fail(`No slug found for: ${JSON.stringify(book)}`)
+    }
+  });
   t.pass()
 })


### PR DESCRIPTION
As part of shifting the source of truth away from the CMS for book
slugs, we're adding the data to live alongside the ABL. The slugs are
defined in a separate file to avoid potential issues that may occur
if we denormalized and included the slug in every ABL entry.

This change includes unit tests that can detect basic issues such as
duplicate UUIDs or missing slugs for books that are on the ABL.