### PR TITLE
Fix broken stepwise lists in Physics

### DIFF
--- a/approved-books.json
+++ b/approved-books.json
@@ -767,6 +767,14 @@
     "server": "cnx.org",
     "uuid": "e42bd376-624b-4c0f-972f-e0c57998e765"
   },
+  {
+    "name": "Physics",
+    "collection_id": "col12081",
+    "style": "hs-physics",
+    "version": "1.14.7",
+    "server": "cnx.org",
+    "uuid": "cce64fde-f448-43b8-ae88-27705cceb0da"
+  },
         {
     "name": "Physics",
     "collection_id": "col12081",


### PR DESCRIPTION
Stepwise lists are display:flexing when there's nested equations in the list so need to import with the class removed.
