### PR TITLE
updated elementary algebra 1e

### DIFF
--- a/approved-books.json
+++ b/approved-books.json
@@ -1032,6 +1032,14 @@
     "server": "cnx.org",
     "uuid": "0889907c-f0ef-496a-bcb8-2a5bb121717f"
   },
+        {
+    "name": "Elementary Algebra 1e",
+    "collection_id": "col12116",
+    "style": "dev-math",
+    "version": "1.9.3",
+    "server": "cnx.org",
+    "uuid": "0889907c-f0ef-496a-bcb8-2a5bb121717f"
+  },
   {
     "name": "Intermediate Algebra 1e",
     "collection_id": "col12119",


### PR DESCRIPTION
the link fix for CE's validation errors had a link point to a module in economics. I changed it to point to the correct module.