### PR TITLE
Switch sociology-3e to tutor_only

### DIFF
--- a/approved-book-list.json
+++ b/approved-book-list.json
@@ -460,7 +460,7 @@
       "collection_id": "col10018",
       "server": "content02.cnx.org",
       "style": "sociology",
-      "tutor_only": false,
+      "tutor_only": true,
       "books": [
         {
           "uuid": "634d7674-0d60-419b-a779-f2b340a7efe0",

--- a/approved-books.json
+++ b/approved-books.json
@@ -608,7 +608,7 @@
     "version": "1.20.1",
     "server": "content02.cnx.org",
     "uuid": "634d7674-0d60-419b-a779-f2b340a7efe0",
-    "tutor_only": false
+    "tutor_only": true
   },
   {
     "name": "Introductory Business Statistics",


### PR DESCRIPTION
I realized afterwards I missed this setting being incorrect when reviewing [PR 61](https://github.com/openstax/content-manager-approved-books/pull/61). This PR corrects `sociology-3e` to be `tutor_only` as discussed in [this Slack thread](https://openstax.slack.com/archives/C0LA54Q5C/p1617390691455900).