### PR TITLE
Update approved-book-list.json

### DIFF
--- a/approved-book-list.json
+++ b/approved-book-list.json
@@ -1004,11 +1004,6 @@
       "min_code_version": "20210224.204120"
     },
     {
-      "collection_id": "col11759",
-      "content_version": "1.29.3",
-      "min_code_version": "20210224.204120"
-    },
-    {
       "collection_id": "col32026",
       "content_version": "1.10.2",
       "min_code_version": "20210224.204120"
@@ -1110,16 +1105,6 @@
     },
     {
       "collection_id": "col32642",
-      "content_version": "1.6.1",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col32642",
-      "content_version": "1.6.2",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col32642",
       "content_version": "1.6.3",
       "min_code_version": "20210224.204120"
     },
@@ -1145,11 +1130,6 @@
     },
     {
       "collection_id": "col11762",
-      "content_version": "1.14.4",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col11762",
       "content_version": "1.15.7",
       "min_code_version": "20210224.204120"
     },
@@ -1161,21 +1141,6 @@
     {
       "collection_id": "col32649",
       "content_version": "1.3.17",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col32649",
-      "content_version": "1.3.10",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col32649",
-      "content_version": "1.3.7",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col32649",
-      "content_version": "1.1.3",
       "min_code_version": "20210224.204120"
     },
     {
@@ -1191,21 +1156,6 @@
     {
       "collection_id": "col11562",
       "content_version": "1.25.23",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col11562",
-      "content_version": "1.25.18",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col11562",
-      "content_version": "1.25.17",
-      "min_code_version": "20210224.204120"
-    },
-    {
-      "collection_id": "col11562",
-      "content_version": "1.25.1",
       "min_code_version": "20210224.204120"
     },
     {


### PR DESCRIPTION
ABL cleaned up to remove failed jobs and leave only two most recent successful pipelines.