### PR TITLE
Update ABL Schema: Added version array with SHA versioning to git-books definition

### DIFF
--- a/abl-schema.json
+++ b/abl-schema.json
@@ -80,7 +80,7 @@
           "type": "string",
           "description": "Style to apply to the content"
         },
-        "platform": {
+        "platforms": {
           "type": "array",
           "items": {
             "enum": ["tutor", "rex"]
@@ -101,7 +101,7 @@
       "required": [
         "repository_name",
         "style",
-        "platform",
+        "platforms",
         "versions"
       ],
       "additionalProperties": false

--- a/abl-schema.json
+++ b/abl-schema.json
@@ -79,7 +79,7 @@
         "platforms": {
           "type": "array",
           "items": {
-            "enum": ["tutor", "rex"]
+            "enum": ["TUTOR", "REX"]
           },
           "description": "The platform(s) this book will be on",
           "minItems": 1,

--- a/abl-schema.json
+++ b/abl-schema.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "api_version": {
+      "type": "number"
+    },
     "approved_books": {
       "$ref": "#/definitions/approved-books"
     },
@@ -10,6 +13,7 @@
     }
   },
   "required": [
+    "api_version",
     "approved_books",
     "approved_versions"
   ],
@@ -76,14 +80,19 @@
           "type": "string",
           "description": "Style to apply to the content"
         },
-        "tutor_only": {
-          "type": "boolean",
-          "description": "When true the book can be only be found on Tutor and is not available on REX"
-        },
-        "books": {
+        "platform": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/book-entry"
+            "enum": ["tutor", "rex"]
+          },
+          "description": "The platform(s) this book will be on",
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/git-version"
           },
           "minItems": 1,
           "uniqueItems": true
@@ -92,7 +101,60 @@
       "required": [
         "repository_name",
         "style",
-        "tutor_only",
+        "platform",
+        "versions"
+      ],
+      "additionalProperties": false
+    },
+    "git-version": {
+      "type": "object",
+      "properties": {
+        "repository_name": {
+          "type": "string",
+          "description": "The git repository name with book version content"
+        },
+        "min_code_version": {
+          "type": "string",
+          "pattern": "^\\d{8}[.]\\d{6}$"
+        },
+        "edition": {
+          "type": "integer",
+          "description": "Human-readable way to tell the edition of a book"
+        },
+        "commit_sha": {
+          "type": "string",
+          "pattern": "^[a-z0-9]{40}$"
+        },
+        "commit_metadata": {
+          "$ref": "#/definitions/commit-metadata"
+        }
+      },
+      "required": [
+        "repository_name",
+        "min_code_version",
+        "edition",
+        "commit_sha",
+        "commit_metadata"
+      ],
+      "additionalProperties": false
+    },
+    "commit-metadata": {
+      "type": "object",
+      "properties": {
+        "committed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Human-readable way to order the books"
+        },
+        "books": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/book-entry"
+          }
+        }
+      },
+      "required": [
+        "committed_at",
         "books"
       ],
       "additionalProperties": false
@@ -119,11 +181,7 @@
     "approved-versions": {
       "type": "array",
       "items": {
-        "oneOf":
-          [
-            { "$ref": "#/definitions/git-version" },
-            { "$ref": "#/definitions/archive-version" }
-          ]
+        "$ref": "#/definitions/archive-version"
       },
       "uniqueItems": true
     },
@@ -147,29 +205,6 @@
       },
       "required": [
         "collection_id",
-        "content_version",
-        "min_code_version"
-      ],
-      "additionalProperties": false
-    },
-    "git-version": {
-      "type": "object",
-      "properties": {
-        "repository_name": {
-          "type": "string",
-          "description": "The git repository name with book content"
-        },
-        "content_version": {
-          "type": "string",
-          "description": "The version of the content to pull from the repository."
-        },
-        "min_code_version": {
-          "type": "string",
-          "description": "The minimum code version required to build."
-        }
-      },
-      "required": [
-        "repository_name",
         "content_version",
         "min_code_version"
       ],

--- a/abl-schema.json
+++ b/abl-schema.json
@@ -76,10 +76,6 @@
           "type": "string",
           "description": "The git repository name with book content"
         },
-        "style": {
-          "type": "string",
-          "description": "Style to apply to the content"
-        },
         "platforms": {
           "type": "array",
           "items": {
@@ -100,7 +96,6 @@
       },
       "required": [
         "repository_name",
-        "style",
         "platforms",
         "versions"
       ],
@@ -109,10 +104,6 @@
     "git-version": {
       "type": "object",
       "properties": {
-        "repository_name": {
-          "type": "string",
-          "description": "The git repository name with book version content"
-        },
         "min_code_version": {
           "type": "string",
           "pattern": "^\\d{8}[.]\\d{6}$"
@@ -130,7 +121,6 @@
         }
       },
       "required": [
-        "repository_name",
         "min_code_version",
         "edition",
         "commit_sha",
@@ -149,7 +139,7 @@
         "books": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/book-entry"
+            "$ref": "#/definitions/git-book-entry"
           }
         }
       },
@@ -173,6 +163,30 @@
         }
       },
       "required": [
+        "uuid",
+        "slug"
+      ],
+      "additionalProperties": false
+    },
+    "git-book-entry": {
+      "type": "object",
+      "properties": {
+        "style": {
+          "type": "string",
+          "description": "Style to apply to the content"
+        },
+        "uuid": {
+          "type": "string",
+          "description": "UUID of the book.",
+          "format": "uuid"
+        },
+        "slug": {
+          "type": "string",
+          "description": "Book slug"
+        }
+      },
+      "required": [
+        "style",
         "uuid",
         "slug"
       ],

--- a/abl-schema.json
+++ b/abl-schema.json
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
     "api_version": {
-      "type": "number"
+      "const": 2
     },
     "approved_books": {
       "$ref": "#/definitions/approved-books"

--- a/approved-book-list.json
+++ b/approved-book-list.json
@@ -3,20 +3,90 @@
   "approved_books": [
     {
       "repository_name": "osbooks-writing-guide",
-      "platforms": ["rex"],
-      "versions": [{
-        "min_code_version": "99999999.999999",
-        "edition": 1,
-        "commit_sha": "4ff250a4779bc500660063acb85b7aab7df94396",
-        "commit_metadata": {
-          "committed_at": "2021-10-25T10:47:06+00:00",
-          "books": [{
-            "style": "english-composition",
-            "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
-            "slug": "writing-guide"
-          }]
+      "platforms": ["REX"],
+      "versions": [
+        {
+          "min_code_version": "20211111.153520",
+          "edition": 1,
+          "commit_sha": "833cc3c75629e1a80585729b054e8cca51f6abe4",
+          "commit_metadata": {
+            "committed_at": "2021-12-02T10:47:06+00:00",
+            "books": [
+              {
+                "style": "english-composition",
+                "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
+                "slug": "writing-guide"
+              }
+            ]
+          }
         }
-      }]
+      ]
+    },
+    {
+      "repository_name": "osbooks-college-algebra-bundle",
+      "platforms": ["REX"],
+      "versions": [
+        {
+          "min_code_version": "20210224.204120",
+          "edition": 1,
+          "commit_sha": "ebc5beb15766e5a72d4d5085c1d470ae868007fb",
+          "commit_metadata": {
+            "committed_at": "2021-09-21T18:42:06+00:00",
+            "books": [
+              {
+                "style": "precalculus",
+                "uuid": "13ac107a-f15f-49d2-97e8-60ab2e3b519c",
+                "slug": "algebra-and-trigonometry"
+              },
+              {
+                "style": "precalculus",
+                "uuid": "9b08c294-057f-4201-9f48-5d6ad992740d",
+                "slug": "college-algebra"
+              },
+              {
+                "style": "precalculus",
+                "uuid": "fd53eae1-fa23-47c7-bb1b-972349835c3c",
+                "slug": "precalculus"
+              },
+              {
+                "style": "precalculus-coreq",
+                "uuid": "507feb1e-cfff-4b54-bc07-d52636cecfe3",
+                "slug": "college-algebra-corequisite-support"
+              }
+            ]
+          }
+        },
+        {
+          "min_code_version": "20211111.153520",
+          "edition": 2,
+          "commit_sha": "fcfa851a18fc910ebd112990270877df9de31cb7",
+          "commit_metadata": {
+            "committed_at": "2021-12-06T15:03:16+00:00",
+            "books": [
+              {
+                "style": "precalculus",
+                "uuid": "13ac107a-f15f-49d2-97e8-60ab2e3b519c",
+                "slug": "algebra-and-trigonometry-2e"
+              },
+              {
+                "style": "precalculus",
+                "uuid": "9b08c294-057f-4201-9f48-5d6ad992740d",
+                "slug": "college-algebra-2e"
+              },
+              {
+                "style": "precalculus",
+                "uuid": "fd53eae1-fa23-47c7-bb1b-972349835c3c",
+                "slug": "precalculus-2e"
+              },
+              {
+                "style": "precalculus-coreq",
+                "uuid": "507feb1e-cfff-4b54-bc07-d52636cecfe3",
+                "slug": "college-algebra-corequisite-support-2e"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "collection_id": "col33604",

--- a/approved-book-list.json
+++ b/approved-book-list.json
@@ -1,15 +1,25 @@
 {
+  "api_version": 2,
   "approved_books": [
     {
       "repository_name": "osbooks-writing-guide",
       "style": "english-composition",
-      "tutor_only": false,
-      "books": [
-        {
-          "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
-          "slug": "writing-guide"
+      "platforms": ["rex"],
+      "versions": [{
+        "repository_name": "osbooks-writing-guide",
+        "min_code_version": "99999999.999999",
+        "edition": 1,
+        "commit_sha": "4ff250a4779bc500660063acb85b7aab7df94396",
+        "commit_metadata": {
+          "committed_at": "2021-10-25T10:47:06+00:00",
+          "books": [
+            {
+              "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
+              "slug": "writing-guide"
+            }
+          ]
         }
-      ]
+      }]
     },
     {
       "collection_id": "col33604",
@@ -1514,11 +1524,6 @@
       "collection_id": "col33393",
       "content_version": "1.1.2",
       "min_code_version": "20210224.204120"
-    },
-    {
-      "repository_name": "osbooks-writing-guide",
-      "content_version": "1",
-      "min_code_version": "99999999.999999"
-  }
+    }
   ]
 }

--- a/approved-book-list.json
+++ b/approved-book-list.json
@@ -3,21 +3,18 @@
   "approved_books": [
     {
       "repository_name": "osbooks-writing-guide",
-      "style": "english-composition",
       "platforms": ["rex"],
       "versions": [{
-        "repository_name": "osbooks-writing-guide",
         "min_code_version": "99999999.999999",
         "edition": 1,
         "commit_sha": "4ff250a4779bc500660063acb85b7aab7df94396",
         "commit_metadata": {
           "committed_at": "2021-10-25T10:47:06+00:00",
-          "books": [
-            {
-              "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
-              "slug": "writing-guide"
-            }
-          ]
+          "books": [{
+            "style": "english-composition",
+            "uuid": "ee7ce46b-0972-4b2c-bc6e-8998c785cd57",
+            "slug": "writing-guide"
+          }]
         }
       }]
     },

--- a/test.js
+++ b/test.js
@@ -58,9 +58,19 @@ test('approved-book-list.json book UUIDs are unique', t => {
   const listData = fs.readFileSync(approvedBookListPath, { encoding: 'utf8' })
   const list = JSON.parse(listData)
   const bookUUIDs = list.approved_books.map(
-    entry => entry.books.map(
-      book => book.uuid
-    )
+    entry => {
+      if(entry.hasOwnProperty("books")) {
+        return entry.books.map(
+          book => book.uuid
+        )
+      } else {
+        return entry.versions.map(
+          version => version.commit_metadata.books.map(
+            book => book.uuid
+          )
+        ).flat()
+      }
+    }
   ).flat()
   bookUUIDs.reduce((acc, entry) =>{
     if (acc.includes(entry)) {
@@ -77,7 +87,7 @@ test('approved-book-list.json has at least one version for each book', t => {
   const abl = JSON.parse(listData)
   abl.approved_books.forEach(b => {
     if (b.repository_name) {
-      t.truthy(abl.approved_versions.find(v => v.repository_name === b.repository_name), `No version for repository_name=${b.repository_name}`)
+      t.truthy(b.versions.length > 0, `No version for repository_name=${b.repository_name}`)
     } else {
       t.truthy(abl.approved_versions.find(v => v.collection_id === b.collection_id), `No version for collection_id=${b.collection_id}`)
     }


### PR DESCRIPTION
I am not sure I understand the scope of the issue or all the business rules for the schema. 
### Questions: 
1. Are there more platforms, or is it only tutor and rex?
1. Should the platform property be an array (can git-books be on more than on platform at a time)?
1. Is updating the git-books that are currently in the ABL to fit this new schema part of this issue?
1. Should the archive-book definition remain the same (including the approved-versions array)?
