### PR TITLE
Update ABL Schema: Add schema version to commit_metadata and book json

### DIFF
--- a/abl-schema.json
+++ b/abl-schema.json
@@ -147,6 +147,7 @@
           "enum": [1, 2, 3]
         }
       },
+      "description": "Derived from the books.xml in the book's GitHub repository",
       "required": [
         "committed_at",
         "books",

--- a/abl-schema.json
+++ b/abl-schema.json
@@ -141,11 +141,16 @@
           "items": {
             "$ref": "#/definitions/git-book-entry"
           }
+        },
+        "schema_version": {
+          "description": "Describes the repo structure and migrations to use",
+          "enum": [1, 2, 3]
         }
       },
       "required": [
         "committed_at",
-        "books"
+        "books",
+        "schema_version"
       ],
       "additionalProperties": false
     },

--- a/approved-book-list.json
+++ b/approved-book-list.json
@@ -10,6 +10,7 @@
           "edition": 1,
           "commit_sha": "833cc3c75629e1a80585729b054e8cca51f6abe4",
           "commit_metadata": {
+            "schema_version": 1,
             "committed_at": "2021-12-02T10:47:06+00:00",
             "books": [
               {
@@ -31,6 +32,7 @@
           "edition": 1,
           "commit_sha": "ebc5beb15766e5a72d4d5085c1d470ae868007fb",
           "commit_metadata": {
+            "schema_version": 1,
             "committed_at": "2021-09-21T18:42:06+00:00",
             "books": [
               {
@@ -61,6 +63,7 @@
           "edition": 2,
           "commit_sha": "970d21eebca11e2838056df5827563f9e0762f5b",
           "commit_metadata": {
+            "schema_version": 1,
             "committed_at": "2021-12-13T14:45:16+00:00",
             "books": [
               {


### PR DESCRIPTION
### Schema version definition
`schema_version` could be an enum,
```json
"enum": [1, 2, 3]
```
or a range,
```json
{
  "type": "number",
  "minimum": 1,
  "maximum": 3
}
```

A range more closely resembles to way we think about versions right now, but an enum is more flexible because it can take on any values (i.e. [1, 3, "4.1"]).

### Schema version description
There was some discussion about how to describe `schema_version`. The current description is `'Describes the repo structure and migrations to use'`.

Any suggestions are welcome.